### PR TITLE
build(deps): bump axios from 1.15.2 to 1.16.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,14 @@ A Node.js/TypeScript library wrapping the Salesforce Bulk API 2.0. Published to 
 - **Build:** `npm run build` (runs `rimraf ./dist && tsc`, outputs CommonJS to `dist/`)
 - **Lint:** `npm run eslint` (ESLint with `@typescript-eslint`)
 - **Dev watch:** `npm run start:dev` (nodemon with ts-node)
-- **No test suite exists.** `npm test` exits with an error by design.
+- **Test:** `npm test` (runs all vitest suites once). Also `npm run test:unit`, `npm run test:integration`, and `npm run test:watch`.
+
+## Tests
+
+Tests use vitest and live in `src/__tests__/`:
+
+- **`bulk2.unit.test.ts`** — unit tests covering the `BulkAPI2` class. These run with no external dependencies and gate publishing via `prepublishOnly` (`npm run build && npm run test:unit`).
+- **`bulk2.integration.test.ts`** — integration tests against a live Salesforce org. Currently skipped (they require real connection credentials).
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "node-sf-bulk2",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-sf-bulk2",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.15.0"
+        "axios": "^1.16.0"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -1312,12 +1312,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -1346,9 +1346,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4612,11 +4612,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "requires": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -4634,9 +4634,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "requires": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "axios": "^1.15.0"
+    "axios": "^1.16.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `axios` `1.15.2` → `1.16.0` (runtime dependency)
- `npm audit fix`: transitive `brace-expansion` `5.0.5` → `5.0.6` (dev-only, moderate DoS advisory via `nodemon` → `minimatch`)
- Update `CLAUDE.md` to document the vitest test suite (unit + integration), replacing the outdated "no test suite exists" note

## Security advisories resolved
axios `1.16.0` is a security release. This bump resolves all 3 open Dependabot alerts on the default branch:

| Severity | Advisory | Vulnerable range | Patched in |
|----------|----------|------------------|------------|
| High | [GHSA-hfxv-24rg-xrqf](https://github.com/advisories/GHSA-hfxv-24rg-xrqf) — ReDoS via Cookie Name Injection | `>= 1.0.0, < 1.16.0` | `1.16.0` |
| High | [GHSA-777c-7fjr-54vf](https://github.com/advisories/GHSA-777c-7fjr-54vf) — Allocation of Resources Without Limits or Throttling | `>= 1.7.0, < 1.16.0` | `1.16.0` |
| Low | [GHSA-654m-c8p4-x5fp](https://github.com/advisories/GHSA-654m-c8p4-x5fp) — Proxy-Authorization Header Injection via Prototype Pollution (patch bypass) | `= 1.15.2` | `1.16.0` |

These alerts will auto-close once this PR merges to `main`.

## Verification
- `npm audit` → 0 vulnerabilities
- `npm run build` → compiles clean
- `npm run eslint` → no lint errors
- `npm test` → 36 passed, 15 skipped (integration tests require live org credentials)

## Notes
The `brace-expansion` advisory was already present on `main` and is unrelated to the axios bump; it lives entirely in dev-dependency territory, so published-package consumers were never affected.