### PR TITLE
feat!: add partial-download result page helpers (v1.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,32 @@ const stream = await bulk.getBulkQueryResultsStream(job.id);
 await pipeline(stream, createWriteStream('results.csv'));
 ```
 
+### Partial / Parallel Downloads
+
+When the `PartialDownloadAndJobEvent` org preference is enabled, a query job's results
+are split into pages that can be downloaded in parallel — and become available while the
+job is still running. Use `getBulkQueryResultPages` to list the page URLs, then
+`getResultPage` / `getResultPageStream` to download each one:
+
+```typescript
+import { createWriteStream } from 'fs';
+import { pipeline } from 'stream/promises';
+
+const pages = await bulk.getBulkQueryResultPages(job.id);
+
+await Promise.all(
+  pages.resultChunks.map(async ({ resultLink }, i) => {
+    // Buffered:
+    const response = await bulk.getResultPage(resultLink);
+    console.log(response.data);
+
+    // …or stream a large page straight to disk:
+    const stream = await bulk.getResultPageStream(resultLink);
+    await pipeline(stream, createWriteStream(`results-page-${i}.csv`));
+  }),
+);
+```
+
 ## Ingest Job — Full Lifecycle
 
 Create an ingest job, upload CSV data, and retrieve results:
@@ -171,7 +197,9 @@ const job = await bulk.createDataUploadJobWithData(
 | `getAllBulkQueryJobInfo(config?)` | List all query jobs (with optional filters) |
 | `getBulkQueryResults(jobId, locator?, maxRecords?)` | Get query results as CSV |
 | `getBulkQueryResultsStream(jobId, locator?, maxRecords?)` | Stream query results as a Node.js Readable |
-| `getBulkQueryResultPages(jobId)` | Get result page URLs for parallel download |
+| `getBulkQueryResultPages(jobId)` | Get result chunk links for partial/parallel download |
+| `getResultPage(resultLink)` | Download a single result chunk as CSV |
+| `getResultPageStream(resultLink)` | Stream a single result chunk as a Node.js Readable |
 | `abortBulkQueryJob(jobId)` | Abort a query job |
 | `deleteBulkQueryJob(jobId)` | Delete a query job |
 

--- a/examples/query-job.ts
+++ b/examples/query-job.ts
@@ -44,6 +44,20 @@ async function main() {
   console.log('\nResults (CSV):');
   console.log(response.data);
 
+  // Partial / parallel downloads (requires the PartialDownloadAndJobEvent org preference).
+  // List the result pages, then download each one individually.
+  try {
+    const pages = await bulk.getBulkQueryResultPages(job.id);
+    console.log(`\nResult chunks available: ${pages.resultChunks.length}`);
+    for (const [i, { resultLink }] of pages.resultChunks.entries()) {
+      const page = await bulk.getResultPage(resultLink);
+      console.log(`\nChunk ${i} (CSV):`);
+      console.log(page.data);
+    }
+  } catch {
+    console.log('\nPartial downloads not available (org preference disabled).');
+  }
+
   // Clean up
   await bulk.deleteBulkQueryJob(job.id);
   console.log('Job deleted.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-sf-bulk2",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-sf-bulk2",
-      "version": "0.2.1",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sf-bulk2",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "Node.js implementation of Salesforce Bulk API 2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/bulk2.integration.test.ts
+++ b/src/__tests__/bulk2.integration.test.ts
@@ -96,6 +96,43 @@ describe.skipIf(!canRun)('BulkAPI2 integration', () => {
       expect(csv).toContain('Id');
     });
 
+    it('downloads result pages (partial/parallel downloads)', async () => {
+      const info = await api.getBulkQueryJobInfo(queryJobId);
+      if (info.state !== 'JobComplete') {
+        console.warn(`Query job ${queryJobId} not complete, skipping result pages test`);
+        return;
+      }
+
+      // resultPages requires the PartialDownloadAndJobEvent org preference; skip if unavailable.
+      let pages;
+      try {
+        pages = await api.getBulkQueryResultPages(queryJobId);
+      } catch {
+        console.warn('resultPages unavailable (PartialDownloadAndJobEvent disabled), skipping');
+        return;
+      }
+      expect(Array.isArray(pages.resultChunks)).toBe(true);
+      if (pages.resultChunks.length === 0) {
+        console.warn('No result chunks returned, skipping page download checks');
+        return;
+      }
+
+      const { resultLink } = pages.resultChunks[0];
+
+      // Buffered download
+      const page = await api.getResultPage(resultLink);
+      expect(page.status).toBe(200);
+      expect(typeof page.data).toBe('string');
+
+      // Streamed download
+      const stream = await api.getResultPageStream(resultLink);
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      expect(Buffer.concat(chunks).toString('utf-8').length).toBeGreaterThan(0);
+    });
+
     it('deletes the query job', async () => {
       await api.deleteBulkQueryJob(queryJobId);
     });

--- a/src/__tests__/bulk2.unit.test.ts
+++ b/src/__tests__/bulk2.unit.test.ts
@@ -311,7 +311,11 @@ describe('BulkAPI2', () => {
 
   describe('getBulkQueryResultPages', () => {
     it('GETs /query/{jobId}/resultPages', async () => {
-      const responseData = { resultPages: [{ resultUrl: '/page1' }], nextRecordsUrl: '', done: true };
+      const responseData = {
+        resultChunks: [{ resultLink: '/jobs/query/q1/results?locator=abc' }],
+        nextRecordsUrl: null,
+        done: true,
+      };
       mockedAxios.get.mockResolvedValueOnce(mockResponse(responseData));
 
       const result = await api.getBulkQueryResultPages('q1');
@@ -321,6 +325,73 @@ describe('BulkAPI2', () => {
         expect.any(Object),
       );
       expect(result).toEqual(responseData);
+    });
+  });
+
+  // resultLink values are relative to the /services/data/vXX.0 base (BASE_ENDPOINT without /jobs).
+  const DATA_URL = 'https://example.salesforce.com/services/data/v62.0';
+
+  describe('getResultPage', () => {
+    it('GETs an absolute resultLink as-is', async () => {
+      const resp = mockResponse('Id,Name\n001,Acme');
+      mockedAxios.get.mockResolvedValueOnce(resp);
+
+      const result = await api.getResultPage(`${DATA_URL}/jobs/query/q1/results?locator=abc`);
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${DATA_URL}/jobs/query/q1/results?locator=abc`,
+        expect.any(Object),
+      );
+      expect(result).toEqual(resp);
+    });
+
+    it('resolves a relative resultLink against the /services/data base', async () => {
+      mockedAxios.get.mockResolvedValueOnce(mockResponse('csv'));
+
+      await api.getResultPage('/jobs/query/q1/results?locator=abc');
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${DATA_URL}/jobs/query/q1/results?locator=abc`,
+        expect.any(Object),
+      );
+    });
+
+    it('inserts a slash for a relative resultLink without a leading slash', async () => {
+      mockedAxios.get.mockResolvedValueOnce(mockResponse('csv'));
+
+      await api.getResultPage('jobs/query/q1/results?locator=abc');
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${DATA_URL}/jobs/query/q1/results?locator=abc`,
+        expect.any(Object),
+      );
+    });
+
+    it('requests CSV via the accept header', async () => {
+      mockedAxios.get.mockResolvedValueOnce(mockResponse('csv'));
+
+      await api.getResultPage('/jobs/query/q1/results?locator=abc');
+
+      const config = mockedAxios.get.mock.calls[0][1]!;
+      expect(config.headers?.accept).toBe('text/csv');
+    });
+  });
+
+  describe('getResultPageStream', () => {
+    it('GETs the resultLink with responseType stream', async () => {
+      const fakeStream = new Readable({ read() { this.push(null); } });
+      mockedAxios.get.mockResolvedValueOnce(mockResponse(fakeStream));
+
+      const result = await api.getResultPageStream('/jobs/query/q1/results?locator=abc');
+
+      expect(result).toBe(fakeStream);
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${DATA_URL}/jobs/query/q1/results?locator=abc`,
+        expect.any(Object),
+      );
+      const config = mockedAxios.get.mock.calls[0][1]!;
+      expect(config.responseType).toBe('stream');
+      expect(config.headers?.accept).toBe('text/csv');
     });
   });
 

--- a/src/bulk2.ts
+++ b/src/bulk2.ts
@@ -18,10 +18,12 @@ export default class BulkAPI2 {
 
     private connection: Connection;
     private endpoint: string;
+    private dataUrl: string;
 
     constructor(connection: Connection) {
         this.connection = connection;
-        this.endpoint = connection.instanceUrl + '/services/data/v' + connection.apiVersion;
+        this.dataUrl = connection.instanceUrl + '/services/data/v' + connection.apiVersion;
+        this.endpoint = this.dataUrl;
         if (this.connection.isTooling) {
             this.endpoint += '/tooling'
         }
@@ -216,6 +218,29 @@ export default class BulkAPI2 {
         const axiosresponse: AxiosResponse = await axois.get(endpoint, requestConfig);
         const response = axiosresponse.data as ParallelQueryResultsResponse;
         return response;
+    }
+
+    private resolveResultLink(resultLink: string): string {
+        if (/^https?:\/\//i.test(resultLink)) {
+            return resultLink;
+        }
+        // resultLink is relative to the /services/data/vXX.0 base (e.g. "/jobs/query/{id}/results?locator=...")
+        return this.dataUrl + (resultLink.startsWith('/') ? '' : '/') + resultLink;
+    }
+
+    public async getResultPage(resultLink: string): Promise<AxiosResponse> {
+        const endpoint = this.resolveResultLink(resultLink);
+        const requestConfig: AxiosRequestConfig = this.getRequestConfig('application/json', 'text/csv');
+        const axiosresponse: AxiosResponse = await axois.get(endpoint, requestConfig);
+        return axiosresponse;
+    }
+
+    public async getResultPageStream(resultLink: string): Promise<Readable> {
+        const endpoint = this.resolveResultLink(resultLink);
+        const requestConfig: AxiosRequestConfig = this.getRequestConfig('application/json', 'text/csv');
+        requestConfig.responseType = 'stream';
+        const axiosresponse: AxiosResponse<Readable> = await axois.get(endpoint, requestConfig);
+        return axiosresponse.data;
     }
 
     public async createDataUploadJobWithData(jobUploadRequest: JobUploadRequest, csvData: string): Promise<JobUploadResponse> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { QueryInput } from "./model/queryInput";
 import {JobUploadRequest} from "./model/jobUploadRequest";
 import {JobUploadResponse} from "./model/jobUploadResponse";
 import {JobInfoResponse} from "./model/jobInfoResponse";
-import { ResultPage, ParallelQueryResultsResponse } from "./model/parallelQueryResultsResponse";
+import { ResultChunk, ParallelQueryResultsResponse } from "./model/parallelQueryResultsResponse";
 
 export {
   AllBulkQueryJobsInfoResponse,
@@ -30,7 +30,7 @@ export {
   OPERATION,
   ParallelQueryResultsResponse,
   QueryInput,
-  ResultPage,
+  ResultChunk,
   RESULTTYPE,
   STATE
 };

--- a/src/model/parallelQueryResultsResponse.ts
+++ b/src/model/parallelQueryResultsResponse.ts
@@ -1,9 +1,9 @@
-export interface ResultPage {
-    resultUrl: string;
+export interface ResultChunk {
+    resultLink: string;
 }
 
 export interface ParallelQueryResultsResponse {
-    resultPages: ResultPage[];
-    nextRecordsUrl: string;
+    resultChunks: ResultChunk[];
+    nextRecordsUrl: string | null;
     done: boolean;
 }


### PR DESCRIPTION
## Summary
Adds helpers to download individual query **result chunks** (partial / parallel downloads, from the `PartialDownloadAndJobEvent` feature) and fixes the `ParallelQueryResultsResponse` model to match the real Bulk V2 API shape.

## Changes
- **New API:** `getResultPage(resultLink)` (buffered) and `getResultPageStream(resultLink)` (Node `Readable`) to download a single result chunk as CSV.
- **Bug fix:** `getBulkQueryResultPages` previously returned all-`undefined` fields — the model declared `resultPages[].resultUrl` but the API returns `resultChunks[].resultLink`. Corrected, and `nextRecordsUrl` is now nullable. `resultLink` values are relative to the `/services/data/vXX.0` base, resolved via a new `dataUrl` field.
- Unit + integration coverage, README "Partial / Parallel Downloads" section, and example usage.

## ⚠️ Breaking change (→ v1.0.0)
- Exported interface `ResultPage` → **`ResultChunk`**
- `ParallelQueryResultsResponse.resultPages` → **`resultChunks`**, element field `resultUrl` → **`resultLink`**
- `nextRecordsUrl` type is now `string | null`

Since the old field names resolved to `undefined` at runtime (the latent bug), nothing functional could have depended on them — but the type surface changes, hence the major bump.

## Verification
- `npm run build` → clean
- `npm run eslint` → clean
- `npm run test:unit` → 41 passed
- `npm run test:integration` → 16 passed against a live org (TDXDevHub), including a real chunk downloaded buffered + streamed